### PR TITLE
FaceLiveness / FaceAuth 5.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 | SDK | Framework |
 | ------- | ------------- |
-| [DocumentDetector](https://docs.caf.io/sdks/ios/getting-started/documentdetector) | `pod 'DocumentDetector', '8.1.4'` |
-| [FaceAuth](https://docs.caf.io/sdks/ios/getting-started/faceauth) | `pod 'FaceAuth', '4.0.1'` |
-| [FaceLiveness](https://docs.caf.io/sdks/ios/getting-started/faceliveness) | `pod 'FaceLiveness', '4.0.0'` |
+| [DocumentDetector](https://docs.caf.io/sdks/ios/getting-started/documentdetector) | `pod 'DocumentDetector', '9.0.1'` |
+| [FaceAuth](https://docs.caf.io/sdks/ios/getting-started/faceauth) | `pod 'FaceAuth', '5.0.0'` |
+| [FaceLiveness](https://docs.caf.io/sdks/ios/getting-started/faceliveness) | `pod 'FaceLiveness', '5.0.0'` |
 
 #### Requirements
 


### PR DESCRIPTION
### `FaceLiveness 5.0.0`

#### Breaking changes

- Updated `public enum ErrorType: String` with new [errorTypes](getting-started/faceliveness.md#error-cases).
- Updated `SDKFailure` now only returns `errorType: ErrorType?` and  `description: String?`, `code: Int?` was removed.

Removed deprecated delegates:
- Removed `didFinishLiveness(with faceLivenessResult: FaceLivenessResult)` from `FaceLivenessDelegate` , use `didFinishLiveness(with livenessResult: LivenessResult)`.
- Removed `didFinishWithCancelled(with faceLivenessResult: FaceLivenessResult)` from `FaceLivenessDelegate` , use `didFinishWithCancelled()`.
- Removed `didFinishWithError(with faceLivenessErrorResult: FaceLivenessErrorResult)` from `FaceLivenessDelegate` , use `didFinishWithError(with sdkFailure: SDKFailure)`.

### `FaceAuth 5.0.0`

#### Breaking changes
- Updated `public enum ErrorType: String` with new [errorTypes](getting-started/faceauth.md#error-cases).
- Removed `code: Int?` from `FaceAuthenticatorErrorResult`.

